### PR TITLE
Trivially expose ARB_shader_image_load_store

### DIFF
--- a/ltw/src/main/tinywrapper/egl.c
+++ b/ltw/src/main/tinywrapper/egl.c
@@ -125,6 +125,8 @@ void build_extension_string(context_t* context) {
     // Used by Minecraft for the GPU usage counter
     if(context->timer_query)
         add_extra_extension(context, &length, "GL_ARB_timer_query");
+    if(context->es31)
+        add_extra_extension(context, &length, "GL_ARB_shader_image_load_store");
     // More extensions are possible, but will need way more wraps and tracking.
     fin_extra_extensions(context, length);
 }


### PR DESCRIPTION
Trivially as the feature is supported since OpenGL ES 3.1. Not tested if it's actually useful.

(maybe) TODO: discover if earlier GLES implementations can support this via EXT/OES extension?