### PR TITLE
Feat[string]: add build date/time to GL_VERSION

### DIFF
--- a/ltw/src/main/tinywrapper/main.c
+++ b/ltw/src/main/tinywrapper/main.c
@@ -307,7 +307,7 @@ const GLubyte* glGetString(GLenum name) {
     if(!current_context) return NULL;
     switch(name) {
         case GL_VERSION:
-            return (const GLubyte*)"3.0 OpenLTW ("__DATE__"/"__TIME__")";
+            return (const GLubyte*)"3.0 OpenLTW (Built on: "__DATE__"/"__TIME__")";
         case GL_SHADING_LANGUAGE_VERSION:
             return (const GLubyte*)"4.60 LTW";
         case GL_VENDOR:

--- a/ltw/src/main/tinywrapper/main.c
+++ b/ltw/src/main/tinywrapper/main.c
@@ -307,7 +307,7 @@ const GLubyte* glGetString(GLenum name) {
     if(!current_context) return NULL;
     switch(name) {
         case GL_VERSION:
-            return (const GLubyte*)"3.0 OpenLTW";
+            return (const GLubyte*)"3.0 OpenLTW ("__DATE__"/"__TIME__")";
         case GL_SHADING_LANGUAGE_VERSION:
             return (const GLubyte*)"4.60 LTW";
         case GL_VENDOR:


### PR DESCRIPTION
Very simple and suckless solution of detecting users with outdated LTW versions. Current commit hash would be even better, but that requires more changes.

Looks like this:
<img width="697" height="73" alt="изображение" src="https://github.com/user-attachments/assets/51e962e5-210d-404e-8bd0-025d7bd0a024" />
