### PR TITLE
[WIP/feat] glClearTexImage()

### DIFF
--- a/ltw/src/main/tinywrapper/egl.c
+++ b/ltw/src/main/tinywrapper/egl.c
@@ -122,6 +122,7 @@ void build_extension_string(context_t* context) {
     // Required by Iris. Indexed variants are available since ES3.2 or with OES/EXT_draw_buffers_indexed extensions
     if(context->blending.available)
         add_extra_extension(context, &length, "GL_ARB_draw_buffers_blend");
+    add_extra_extension(context, &length, "GL_ARB_clear_texture");
     // Used by Minecraft for the GPU usage counter (see Blaze3D TimerQuery)
     add_extra_extension(context, &length, "GL_ARB_timer_query");
     // More extensions are possible, but will need way more wraps and tracking.

--- a/ltw/src/main/tinywrapper/of_buffer_copier.c
+++ b/ltw/src/main/tinywrapper/of_buffer_copier.c
@@ -169,5 +169,20 @@ void glCopyTexSubImage2D(GLenum target,
             texture_blit_framebuffer(target, level, xoffset, yoffset, x, y, width, height, true);
         }
     }
+}
 
+void glClearTexImage(GLuint texture,
+                     GLint level,
+                     GLenum format,
+                     GLenum type,
+                     const void * data) {
+    if(!current_context) return;
+    framebuffer_copier_t* copier = &current_context->framebuffer_copier;
+    if(!copier->ready) return;
+
+    es3_functions.glBindFramebuffer(GL_DRAW_FRAMEBUFFER, copier->tempfb);
+    es3_functions.glFramebufferTexture2D(copier->tempfb, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, level);
+    es3_functions.glClearBufferiv(GL_COLOR, GL_COLOR_ATTACHMENT0, data);
+    es3_functions.glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    printf("LTW: Cleared framebuffer texture\n");
 }

--- a/ltw/src/main/tinywrapper/of_buffer_copier.c
+++ b/ltw/src/main/tinywrapper/of_buffer_copier.c
@@ -184,5 +184,4 @@ void glClearTexImage(GLuint texture,
     es3_functions.glFramebufferTexture2D(copier->tempfb, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, level);
     es3_functions.glClearBufferiv(GL_COLOR, GL_COLOR_ATTACHMENT0, data);
     es3_functions.glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-    printf("LTW: Cleared framebuffer texture\n");
 }


### PR DESCRIPTION
Emulate glClearTexImage using a temporary FBO created in the buffer copier. Not sure if this works.