### PR TITLE
Fix[shader_wrapper]: do not accept optimized shader source if failed

### DIFF
--- a/ltw/src/main/tinywrapper/shader_wrapper.c
+++ b/ltw/src/main/tinywrapper/shader_wrapper.c
@@ -194,12 +194,13 @@ void glShaderSource(GLuint shader, GLsizei count, const GLchar *const*string, co
     GLchar* new_source = optimize_shader(target_string, shader_info->shader_type, 460, current_context->shader_version);
     if(shader_info->source != NULL) free((void*)shader_info->source);
     if(!new_source) {
-        printf("LTWShdrWp: failed to optimize shader %u, skipping\n", shader);
-        return;
+        printf("LTWShdrWp: failed to convert&optimize shader %u, skipping\n", shader);
+        goto end;
     } else {
         //printf("\n\n\nShader Result\n%s\n\n\n", new_source);
         shader_info->source = new_source;
     }
     es3_functions.glShaderSource(shader, 1, &shader_info->source, 0);
+    end:
     free(target_string);
 }

--- a/ltw/src/main/tinywrapper/shader_wrapper.c
+++ b/ltw/src/main/tinywrapper/shader_wrapper.c
@@ -192,9 +192,14 @@ void glShaderSource(GLuint shader, GLsizei count, const GLchar *const*string, co
 
 #undef SRC_LEN
     GLchar* new_source = optimize_shader(target_string, shader_info->shader_type, 460, current_context->shader_version);
-    //printf("\n\n\nShader Result\n%s\n\n\n", new_source);
     if(shader_info->source != NULL) free((void*)shader_info->source);
-    shader_info->source = new_source;
+    if(!new_source) {
+        printf("LTWShdrWp: failed to optimize shader %u, skipping\n", shader);
+        shader_info->source = target_string;
+    } else {
+        //printf("\n\n\nShader Result\n%s\n\n\n", new_source);
+        shader_info->source = new_source;
+    }
     es3_functions.glShaderSource(shader, 1, &shader_info->source, 0);
     free(target_string);
 }

--- a/ltw/src/main/tinywrapper/shader_wrapper.c
+++ b/ltw/src/main/tinywrapper/shader_wrapper.c
@@ -195,7 +195,7 @@ void glShaderSource(GLuint shader, GLsizei count, const GLchar *const*string, co
     if(shader_info->source != NULL) free((void*)shader_info->source);
     if(!new_source) {
         printf("LTWShdrWp: failed to optimize shader %u, skipping\n", shader);
-        shader_info->source = target_string;
+        return;
     } else {
         //printf("\n\n\nShader Result\n%s\n\n\n", new_source);
         shader_info->source = new_source;


### PR DESCRIPTION
Because it returns NULL and causes UB. Not tested.